### PR TITLE
Initialize Starlight site with home page and chapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
-# historiacea.github.io
-Historia del pueblo de Cea en Leon
+# Historia de Cea
+
+Sitio web construido con [Astro](https://astro.build) y [Starlight](https://starlight.astro.build).
+
+## Desarrollo local
+
+Requiere Node.js. Una vez instaladas las dependencias:
+
+```bash
+npm install
+npm run dev
+```

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,0 +1,11 @@
+import { defineConfig } from 'astro/config';
+import starlight from '@astrojs/starlight';
+
+export default defineConfig({
+  integrations: [
+    starlight({
+      title: 'Historia de Cea',
+      description: 'Relatos y crónicas de Cea, León',
+    })
+  ],
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "historiacea",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Historia del pueblo de Cea en León",
+  "type": "module",
+  "scripts": {
+    "dev": "astro dev",
+    "build": "astro build",
+    "preview": "astro preview",
+    "test": "echo 'No tests specified'"
+  },
+  "dependencies": {
+  },
+  "devDependencies": {
+    "astro": "^4.0.0",
+    "@astrojs/starlight": "^0.15.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="50" fill="#1d4ed8"/>
+  <text x="50" y="70" font-size="60" text-anchor="middle" fill="white">C</text>
+</svg>

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -1,0 +1,13 @@
+import { defineCollection } from 'astro:content';
+import { docsSchema, i18nSchema } from '@astrojs/starlight/schema';
+
+const docs = defineCollection({
+  schema: docsSchema(),
+});
+
+const i18n = defineCollection({
+  type: 'data',
+  schema: i18nSchema(),
+});
+
+export const collections = { docs, i18n };

--- a/src/content/docs/capitulo-1.mdx
+++ b/src/content/docs/capitulo-1.mdx
@@ -1,0 +1,5 @@
+---
+title: "Capítulo 1: Orígenes"
+---
+
+Los primeros asentamientos en Cea se remontan a la época prerromana, cuando tribus astures habitaban estas tierras.

--- a/src/content/docs/capitulo-2.mdx
+++ b/src/content/docs/capitulo-2.mdx
@@ -1,0 +1,5 @@
+---
+title: "Capítulo 2: Época Medieval"
+---
+
+Durante la Edad Media, Cea se consolidó como un enclave estratégico en el Reino de León, protegido por sus murallas y castillo.

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -1,0 +1,8 @@
+---
+title: "Historia de Cea, León"
+description: "Bienvenido"
+---
+
+# Historia de Cea, León
+
+Bienvenido a esta recopilación de la historia de nuestro pueblo Cea, ubicado en la provincia de León. Aquí encontrarás capítulos que narran su pasado y sus tradiciones.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "astro/tsconfigs/strict"
+}


### PR DESCRIPTION
## Summary
- scaffolded Astro project with Starlight integration for "Historia de Cea"
- added homepage and two chapter documents recounting the town's history
- added development configuration and basic favicon

## Testing
- `npm test`
- `npm run build` *(fails: sh: 1: astro: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4db94f06483219a20243f94f78b2f