### PR TITLE
chore: enable GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,40 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm install
+      - run: npm run build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -1,13 +1,8 @@
 import { defineCollection } from 'astro:content';
-import { docsSchema, i18nSchema } from '@astrojs/starlight/schema';
+import { docsSchema } from '@astrojs/starlight/schema';
 
 const docs = defineCollection({
   schema: docsSchema(),
 });
 
-const i18n = defineCollection({
-  type: 'data',
-  schema: i18nSchema(),
-});
-
-export const collections = { docs, i18n };
+export const collections = { docs };


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and deploy Astro site
- remove unused i18n content collection so build succeeds

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4e357b20083219cb9b295dc2e62ad