### PR TITLE
Add sidebar topics plugin and top navigation links

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,5 +1,6 @@
 import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
+import sidebarTopics from 'starlight-sidebar-topics';
 
 export default defineConfig({
   site: 'https://historiacea.github.io',
@@ -17,7 +18,8 @@ export default defineConfig({
         }
       ],
       sidebar: [
-        { label: 'Índice', link: '/indice/' },
+        { label: 'Inicio', link: '/', icon: 'i-heroicons-home', style: 'outline' },
+        { label: 'Índice', link: '/indice/', icon: 'i-heroicons-list-bullet', style: 'outline' },
         {
           label: 'Capítulos',
           items: [
@@ -30,6 +32,7 @@ export default defineConfig({
       components: {
         Header: './src/components/Header.astro',
       },
+      plugins: [sidebarTopics()],
     })
   ],
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "devDependencies": {
         "@astrojs/starlight": "^0.15.0",
         "astro": "^4.0.0",
-        "typescript": "^5.0.0"
+        "typescript": "^5.0.0",
+        "starlight-sidebar-topics": "^0.1.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -40,6 +41,10 @@
       "integrity": "sha512-bMf9jFihO8YP940uD70SI/RDzIhUHJAolWVcO1v5PUivxGKvfLZTLTVVxEYzGYyPsA3ivdLNqMnL5VgmQySa+g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/starlight-sidebar-topics": {
+      "version": "0.1.0",
+      "dev": true
     },
     "node_modules/@astrojs/markdown-remark": {
       "version": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "devDependencies": {
     "astro": "^4.0.0",
     "@astrojs/starlight": "^0.15.0",
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0",
+    "starlight-sidebar-topics": "^0.1.0"
   }
 }

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -2,6 +2,7 @@
 title: "Historia de Cea, León"
 description: "Recorrido por la historia del pueblo de Cea desde sus orígenes hasta la actualidad"
 template: splash
+sidebar: false
 hero:
   tagline: "Recorrido por la historia del pueblo de Cea desde sus orígenes hasta la actualidad"
   actions:

--- a/src/content/docs/indice.mdx
+++ b/src/content/docs/indice.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Índice de capítulos"
 description: "Accede a todos los capítulos de la historia del pueblo de Cea."
+sidebar: false
 ---
 
 # Índice de capítulos


### PR DESCRIPTION
## Summary
- add `starlight-sidebar-topics` plugin to Astro config
- show Inicio and Índice links with icons at the top of the sidebar and hide duplicates from bottom

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a56cc1b6888321bd0122b9752c3193