### PR TITLE
feat: add image zoom plugin

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,6 +1,7 @@
 import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
-import sidebarTopics from 'starlight-sidebar-topics';
+import starlightSidebarTopics from 'starlight-sidebar-topics';
+import starlightImageZoom from 'starlight-image-zoom';
 
 export default defineConfig({
   site: 'https://historiacea.github.io',
@@ -32,7 +33,7 @@ export default defineConfig({
       components: {
         Header: './src/components/Header.astro',
       },
-      plugins: [sidebarTopics()],
+      plugins: [starlightSidebarTopics(), starlightImageZoom()],
     })
   ],
 });

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "astro": "^4.0.0",
     "@astrojs/starlight": "^0.15.0",
     "typescript": "^5.0.0",
-    "starlight-sidebar-topics": "^0.1.0"
+    "starlight-sidebar-topics": "^0.1.0",
+    "starlight-image-zoom": "^0.1.0"
   }
 }

--- a/public/cea.svg
+++ b/public/cea.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+  <rect width="200" height="200" fill="#e63946"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="24" fill="#fff">Cea</text>
+</svg>

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -11,4 +11,6 @@ hero:
 ---
 Bienvenidos a este viaje por la historia del pueblo de Cea, León. Nuestra intención es recopilar y difundir los episodios más destacados de su trayectoria para conservar la memoria de la comunidad.
 
+![Vista de Cea](/cea.svg)
+
 <iframe src="https://www.google.com/maps?q=Cea,Le%C3%B3n,Spain&output=embed" width="100%" height="450" style="border:0;" allowfullscreen loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>


### PR DESCRIPTION
## Summary
- configure starlight-image-zoom plugin
- add a sample image on the home page
- fix sidebar topics plugin reference

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/starlight-image-zoom)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a56e0ddb5883218f13641c539057d5