### PR TITLE
fix: update Starlight dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "historiacea",
       "version": "0.0.1",
       "devDependencies": {
-        "@astrojs/starlight": "^0.15.0",
+        "@astrojs/starlight": "^0.20.0",
         "astro": "^4.0.0",
         "typescript": "^5.0.0",
         "starlight-sidebar-topics": "^0.1.0"
@@ -126,35 +126,6 @@
         "sitemap": "^8.0.0",
         "stream-replace-string": "^2.0.0",
         "zod": "^3.24.4"
-      }
-    },
-    "node_modules/@astrojs/starlight": {
-      "version": "0.15.4",
-      "resolved": "https://registry.npmjs.org/@astrojs/starlight/-/starlight-0.15.4.tgz",
-      "integrity": "sha512-o3heYH+RltsCsvO3L0qLnnFJEakwLSRoxW4wFX2zDeDWta9BIpdSOo7+Zg+sSn7k9RPOhI9SGvdFx67B53I18Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@astrojs/mdx": "^2.0.4",
-        "@astrojs/sitemap": "^3.0.4",
-        "@pagefind/default-ui": "^1.0.3",
-        "@types/hast": "^3.0.3",
-        "@types/mdast": "^4.0.3",
-        "astro-expressive-code": "^0.31.0",
-        "bcp-47": "^2.1.0",
-        "hast-util-select": "^6.0.2",
-        "hastscript": "^8.0.0",
-        "mdast-util-directive": "^3.0.0",
-        "pagefind": "^1.0.3",
-        "rehype": "^13.0.1",
-        "remark-directive": "^3.0.0",
-        "unified": "^11.0.4",
-        "unist-util-remove": "^4.0.0",
-        "unist-util-visit": "^5.0.0",
-        "vfile": "^6.0.1"
-      },
-      "peerDependencies": {
-        "astro": "^4.0.0"
       }
     },
     "node_modules/@astrojs/telemetry": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "astro": "^4.0.0",
-    "@astrojs/starlight": "^0.15.0",
+    "@astrojs/starlight": "^0.20.0",
     "typescript": "^5.0.0",
     "starlight-sidebar-topics": "^0.1.0",
     "starlight-image-zoom": "^0.1.0"


### PR DESCRIPTION
## Summary
- update @astrojs/starlight to ^0.20.0 to satisfy starlight-image-zoom peer requirements
- remove outdated lockfile entry for previous Starlight version

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/astro-expressive-code)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5700e64d08321b932f6f346d94e33