### PR TITLE
chore: remove Starlight Sidebar Topics plugin

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,6 +1,5 @@
 import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
-import starlightSidebarTopics from 'starlight-sidebar-topics';
 import starlightImageZoom from 'starlight-image-zoom';
 
 export default defineConfig({
@@ -33,7 +32,7 @@ export default defineConfig({
       components: {
         Header: './src/components/Header.astro',
       },
-      plugins: [starlightSidebarTopics(), starlightImageZoom()],
+      plugins: [starlightImageZoom()],
     })
   ],
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,7 @@
       "devDependencies": {
         "@astrojs/starlight": "^0.20.0",
         "astro": "^4.0.0",
-        "typescript": "^5.0.0",
-        "starlight-sidebar-topics": "^0.1.0"
+        "typescript": "^5.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -41,10 +40,6 @@
       "integrity": "sha512-bMf9jFihO8YP940uD70SI/RDzIhUHJAolWVcO1v5PUivxGKvfLZTLTVVxEYzGYyPsA3ivdLNqMnL5VgmQySa+g==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/starlight-sidebar-topics": {
-      "version": "0.1.0",
-      "dev": true
     },
     "node_modules/@astrojs/markdown-remark": {
       "version": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "astro": "^4.0.0",
     "@astrojs/starlight": "^0.20.0",
     "typescript": "^5.0.0",
-    "starlight-sidebar-topics": "^0.1.0",
     "starlight-image-zoom": "^0.1.0"
   }
 }


### PR DESCRIPTION
## Summary
- remove Starlight Sidebar Topics integration
- drop unused plugin dependency

## Testing
- `npm test`
- `npm run build` *(fails: astro: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a57c2481f883219505537df946c7b6